### PR TITLE
docs: improve public issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -45,9 +45,11 @@ body:
       description: |
         What actually happened?
 
-        Please include full errors, uncaught exceptions, stack traces, and
-        relevant logs. If service/functions responses are relevant, please
-        include wire logs.
+        Please include relevant errors, exceptions, stack traces, and logs.
+        Redact secrets, tokens, credentials, private URLs, account IDs, and
+        any personal or customer data before posting.
+
+        If wire logs are relevant, share only sanitized excerpts.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,80 +1,116 @@
 ---
-name: Bug report
-description: Report a reproducible bug or unexpected behavior
-title: "[Bug]: "
-labels: [bug, needs-triage]
-type: Bug
+name: "🐛 Bug Report"
+description: Report a bug
+title: "[BUG]: short issue description"
+labels: [bug]
+assignees: []
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting a bug. Please provide enough detail for a
-        maintainer or contributor to reproduce it without access to private
-        systems.
+        Thanks for taking the time to fill out this bug report 🤗
+        Make sure there aren't any open/closed issues for this topic 😃
+        Please fill out the sections below to help us understand the issue.
 
   - type: checkboxes
     id: search
     attributes:
-      label: Existing issues
-      description: Please search before opening a new issue.
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists.
       options:
-        - label: I have searched existing open and closed issues
+        - label: I have searched the existing issues
           required: true
 
   - type: textarea
-    id: summary
+    id: description
     attributes:
-      label: Summary
-      description: What is broken?
-    validations:
-      required: true
-
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: Steps to reproduce
-      description: Provide the smallest reproducible case.
-      placeholder: |
-        1. Clone the repository
-        2. Run `...`
-        3. See `...`
+      label: Describe the bug
+      description: What is the problem? A clear and concise bug description.
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: Expected behavior
-      description: What did you expect to happen?
+      label: Expected Behavior
+      description: |
+        What did you expect to happen?
     validations:
       required: true
 
   - type: textarea
-    id: actual
+    id: current
     attributes:
-      label: Actual behavior
-      description: What happened instead?
+      label: Current Behavior
+      description: |
+        What actually happened?
+
+        Please include full errors, uncaught exceptions, stack traces, and
+        relevant logs. If service/functions responses are relevant, please
+        include wire logs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: |
+        Provide a self-contained, concise snippet of code that can be used to
+        reproduce the issue. For more complex issues provide a repo with the
+        smallest sample that reproduces the bug.
+
+        Avoid including business logic or unrelated code, it makes diagnosis
+        more difficult. The code sample should be an SSCCE. See
+        http://sscce.org/ for details.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Possible Solution
+      description: |
+        Suggest a fix/reason for the bug
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Information/Context
+      description: |
+        Anything else that might be relevant for troubleshooting this bug.
+        Providing context helps us come up with a solution that is most useful
+        in the real world.
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version used
+      description: |
+        Please provide the version of the repository or tool you are using.
     validations:
       required: true
 
   - type: textarea
     id: environment
     attributes:
-      label: Environment
-      description: Include relevant versions and platform details.
-      value: |
+      label: Environment details (OS name and version, etc.)
+      placeholder: |
         - OS:
         - Runtime/tool version:
-        - Package manager/version:
-        - Repository commit or release:
+        - Package manager:
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: logs
     attributes:
-      label: Relevant logs or screenshots
-      description: Paste logs without secrets or tokens.
+      label: Relevant log output
+      description: Copy and paste any relevant log output.
       render: shell
     validations:
       required: false
@@ -82,10 +118,9 @@ body:
   - type: checkboxes
     id: public-safety
     attributes:
-      label: Public-safety confirmation
+      label: Public issue checklist
       options:
-        - label: This report does not include secrets, tokens, private URLs,
-            or internal-only project references
+        - label: This issue does not include secrets or private project links
           required: true
 
   - type: checkboxes
@@ -93,5 +128,5 @@ body:
     attributes:
       label: Contribution
       options:
-        - label: I am willing to submit a pull request with a fix
+        - label: I may be able to submit a pull request for this bug
           required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,3 +1,4 @@
+---
 name: Bug report
 description: Report a reproducible bug or unexpected behavior
 title: "[Bug]: "
@@ -7,7 +8,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting a bug. Please provide enough detail for a maintainer or contributor to reproduce it without access to private systems.
+        Thanks for reporting a bug. Please provide enough detail for a
+        maintainer or contributor to reproduce it without access to private
+        systems.
 
   - type: checkboxes
     id: search
@@ -81,7 +84,8 @@ body:
     attributes:
       label: Public-safety confirmation
       options:
-        - label: This report does not include secrets, tokens, private URLs, or internal-only project references
+        - label: This report does not include secrets, tokens, private URLs,
+            or internal-only project references
           required: true
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,75 +1,93 @@
----
-name: "🐛 Bug Report"
-description: Report a bug
-title: "(short issue description)"
-labels: [bug]
-assignees: []
+name: Bug report
+description: Report a reproducible bug or unexpected behavior
+title: "[Bug]: "
+labels: [bug, needs-triage]
+type: Bug
 body:
-  - type: textarea
-    id: description
+  - type: markdown
     attributes:
-      label: Describe the bug
-      description: What is the problem? A clear and concise description of the bug.
-    validations:
-      required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected Behavior
-      description: |
-        What did you expect to happen?
-    validations:
-      required: true
-  - type: textarea
-    id: current
-    attributes:
-      label: Current Behavior
-      description: |
-        What actually happened?
+      value: |
+        Thanks for reporting a bug. Please provide enough detail for a maintainer or contributor to reproduce it without access to private systems.
 
-        Please include full errors, uncaught exceptions, stack traces, and relevant logs.
-        If service/functions responses are relevant, please include wire logs.
+  - type: checkboxes
+    id: search
+    attributes:
+      label: Existing issues
+      description: Please search before opening a new issue.
+      options:
+        - label: I have searched existing open and closed issues
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
     validations:
       required: true
+
   - type: textarea
     id: reproduction
     attributes:
-      label: Reproduction Steps
-      description: |
-        Provide a self-contained, concise snippet of code that can be used to reproduce the issue.
-        For more complex issues provide a repo with the smallest sample that reproduces the bug.
+      label: Steps to reproduce
+      description: Provide the smallest reproducible case.
+      placeholder: |
+        1. Clone the repository
+        2. Run `...`
+        3. See `...`
+    validations:
+      required: true
 
-        Avoid including business logic or unrelated code, it makes diagnosis more difficult.
-        The code sample should be an SSCCE. See http://sscce.org/ for details. In short, please provide a code sample that we can copy/paste, run and reproduce.
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
     validations:
       required: true
+
   - type: textarea
-    id: solution
+    id: actual
     attributes:
-      label: Possible Solution
-      description: |
-        Suggest a fix/reason for the bug
-    validations:
-      required: false
-  - type: textarea
-    id: context
-    attributes:
-      label: Additional Information/Context
-      description: |
-        Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful in the real world.
-    validations:
-      required: false
-  - type: input
-    id: version
-    attributes:
-      label: Version used
-      description: |
-        Please provide the version of the repository or tool you are using.
+      label: Actual behavior
+      description: What happened instead?
     validations:
       required: true
-  - type: input
+
+  - type: textarea
     id: environment
     attributes:
-      label: Environment details (OS name and version, etc.)
+      label: Environment
+      description: Include relevant versions and platform details.
+      value: |
+        - OS:
+        - Runtime/tool version:
+        - Package manager/version:
+        - Repository commit or release:
     validations:
-      required: true
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Paste logs without secrets or tokens.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: public-safety
+    attributes:
+      label: Public-safety confirmation
+      options:
+        - label: This report does not include secrets, tokens, private URLs, or internal-only project references
+          required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to submit a pull request with a fix
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,6 @@
+---
 blank_issues_enabled: false
 contact_links:
   - name: NaNLABS GitHub organization
     url: https://github.com/nanlabs
-    about: For general public information about NaNLABS open-source repositories.
+    about: For public information about NaNLABS open source repositories.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,5 @@
----
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 General Question
-    url: https://github.com/nanlabs/devops-reference/discussions/categories/q-a
-    about: Please ask and answer questions as a discussion thread
+  - name: NaNLABS GitHub organization
+    url: https://github.com/nanlabs
+    about: For general public information about NaNLABS open-source repositories.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,51 +1,39 @@
 ---
-name: Documentation
-description: Report a documentation gap or improvement
-title: "[Docs]: "
-labels: [documentation, needs-triage]
-type: Task
+name: "📕 Documentation Issue"
+description: Report an issue in the Reference documentation or Developer Guide
+title: "(short issue description)"
+labels: [documentation]
+assignees: []
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve the documentation. Please include public
-        links only.
+        Thanks for helping us improve our documentation 📚
 
   - type: textarea
-    id: gap
+    id: description
     attributes:
-      label: What needs to be documented?
-      description: Describe the missing or stale documentation.
+      label: Describe the issue
+      description: A clear and concise description of the issue.
     validations:
       required: true
 
   - type: textarea
-    id: location
+    id: links
     attributes:
-      label: Where should this live?
-      description: Specific file, section, or documentation area.
-      placeholder: README.md, CONTRIBUTING.md, docs/..., example README, etc.
+      label: Links
+      description: |
+        Include links to affected documentation page(s).
     validations:
       required: true
 
   - type: textarea
-    id: suggested-content
+    id: suggestion
     attributes:
-      label: Suggested content or outline
-      description: Share a draft, outline, or examples if available.
+      label: Suggested Content
+      description: If you have a draft, outline, or examples, share them here.
     validations:
       required: false
-
-  - type: textarea
-    id: acceptance-criteria
-    attributes:
-      label: Acceptance criteria
-      value: |
-        - [ ] The documentation explains ...
-        - [ ] Public links are valid
-        - [ ] Examples or commands are accurate
-    validations:
-      required: true
 
   - type: textarea
     id: validation
@@ -53,24 +41,17 @@ body:
       label: Validation
       description: How should the documentation change be checked?
       value: |
-        - [ ] Run markdown lint checks if available
         - [ ] Verify all links resolve
+        - [ ] Run markdown lint checks if available
     validations:
       required: false
 
   - type: checkboxes
-    id: public-safety
+    id: ack
     attributes:
-      label: Public-safety confirmation
+      label: Acknowledgements
       options:
-        - label: This request does not include secrets, private URLs, or
-            internal-only project references
-          required: true
-
-  - type: checkboxes
-    id: contribution
-    attributes:
-      label: Contribution
-      options:
-        - label: I would like to work on this
+        - label: I may be able to submit a pull request for this documentation
           required: false
+        - label: This issue does not include secrets or private project links
+          required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -15,7 +15,7 @@ body:
     id: gap
     attributes:
       label: What needs to be documented?
-      description: Describe the missing, stale, confusing, or incorrect documentation.
+      description: Describe the missing or stale documentation.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,3 +1,4 @@
+---
 name: Documentation
 description: Report a documentation gap or improvement
 title: "[Docs]: "
@@ -7,7 +8,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve the documentation. Please include public links only.
+        Thanks for helping improve the documentation. Please include public
+        links only.
 
   - type: textarea
     id: gap
@@ -61,7 +63,8 @@ body:
     attributes:
       label: Public-safety confirmation
       options:
-        - label: This request does not include secrets, private URLs, or internal-only project references
+        - label: This request does not include secrets, private URLs, or
+            internal-only project references
           required: true
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,22 +1,73 @@
-name: "📕 Documentation Issue"
-description: Report an issue in the Reference documentation or Developer Guide
-title: "(short issue description)"
-labels: [documentation]
-assignees: []
+name: Documentation
+description: Report a documentation gap or improvement
+title: "[Docs]: "
+labels: [documentation, needs-triage]
+type: Task
 body:
-  - type: textarea
-    id: description
+  - type: markdown
     attributes:
-      label: Describe the issue
-      description: A clear and concise description of the issue.
+      value: |
+        Thanks for helping improve the documentation. Please include public links only.
+
+  - type: textarea
+    id: gap
+    attributes:
+      label: What needs to be documented?
+      description: Describe the missing, stale, confusing, or incorrect documentation.
     validations:
       required: true
 
   - type: textarea
-    id: links
+    id: location
     attributes:
-      label: Links
-      description: |
-        Include links to affected documentation page(s).
+      label: Where should this live?
+      description: Specific file, section, or documentation area.
+      placeholder: README.md, CONTRIBUTING.md, docs/..., example README, etc.
     validations:
       required: true
+
+  - type: textarea
+    id: suggested-content
+    attributes:
+      label: Suggested content or outline
+      description: Share a draft, outline, or examples if available.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ] The documentation explains ...
+        - [ ] Public links are valid
+        - [ ] Examples or commands are accurate
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: How should the documentation change be checked?
+      value: |
+        - [ ] Run markdown lint checks if available
+        - [ ] Verify all links resolve
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: public-safety
+    attributes:
+      label: Public-safety confirmation
+      options:
+        - label: This request does not include secrets, private URLs, or internal-only project references
+          required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I would like to work on this
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -54,9 +54,9 @@ body:
       label: Acceptance criteria
       description: How will maintainers know this is complete?
       value: |
-        - [ ] 
-        - [ ] 
-        - [ ] 
+        - [ ] Add the expected behavior
+        - [ ] Update tests or docs when applicable
+        - [ ] Document validation steps
     validations:
       required: true
 
@@ -66,7 +66,7 @@ body:
       label: Validation
       description: Which tests, commands, or manual checks should pass?
       value: |
-        - [ ] 
+        - [ ] Run the relevant local checks
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,61 +1,85 @@
----
-name: 🚀 Feature Request
-description: Suggest an idea for this project
-title: "(short issue description)"
-labels: [feature-request]
-assignees: []
+name: Feature request
+description: Suggest an improvement or new capability
+title: "[Feature]: "
+labels: [enhancement, needs-triage]
+type: Feature
 body:
-  - type: textarea
-    id: description
+  - type: markdown
     attributes:
-      label: Describe the feature
-      description: A clear and concise description of the feature you are proposing.
+      value: |
+        Thanks for suggesting an improvement. Please keep the proposal public-safe and avoid private project links.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this solve?
+      placeholder: It is difficult to...
     validations:
       required: true
+
   - type: textarea
-    id: use-case
+    id: proposed-solution
     attributes:
-      label: Use Case
-      description: |
-        Why do you need this feature? For example: "I'm always frustrated when..."
+      label: Proposed solution
+      description: How should this work?
     validations:
       required: true
+
   - type: textarea
-    id: solution
+    id: scope
     attributes:
-      label: Proposed Solution
-      description: |
-        Suggest how to implement the addition or change. Please include prototype/workaround/sketch/reference implementation.
+      label: Scope
+      description: What should be included?
+      placeholder: |
+        - Add ...
+        - Update ...
+        - Document ...
     validations:
       required: false
+
   - type: textarea
-    id: other
+    id: alternatives
     attributes:
-      label: Other Information
-      description: |
-        Any alternative solutions or features you considered, a more detailed explanation, stack traces, related issues, links for context, etc.
+      label: Alternatives considered
+      description: What alternatives or workarounds did you consider?
     validations:
       required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: How will maintainers know this is complete?
+      value: |
+        - [ ] 
+        - [ ] 
+        - [ ] 
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: Which tests, commands, or manual checks should pass?
+      value: |
+        - [ ] 
+    validations:
+      required: false
+
   - type: checkboxes
-    id: ack
+    id: public-safety
     attributes:
-      label: Acknowledgements
+      label: Public-safety confirmation
       options:
-        - label: I may be able to implement this feature request
-          required: false
-        - label: This feature might incur a breaking change
-          required: false
-  - type: input
-    id: version
+        - label: This request does not include secrets, private URLs, or internal-only project references
+          required: true
+
+  - type: checkboxes
+    id: contribution
     attributes:
-      label: Version used
-      description: |
-        Please provide the version of the repository or tool you are using.
-    validations:
-      required: true
-  - type: input
-    id: environment
-    attributes:
-      label: Environment details (OS name and version, etc.)
-    validations:
-      required: true
+      label: Contribution
+      options:
+        - label: I am willing to submit a pull request for this feature
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,88 +1,90 @@
 ---
-name: Feature request
-description: Suggest an improvement or new capability
-title: "[Feature]: "
-labels: [enhancement, needs-triage]
-type: Feature
+name: 🚀 Feature Request
+description: Suggest an idea for this project
+title: "(short issue description)"
+labels: [feature-request, enhancement]
+assignees: []
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for suggesting an improvement. Please keep the proposal public
-        safe and avoid private project links.
-
   - type: textarea
-    id: problem
+    id: description
     attributes:
-      label: Problem statement
-      description: What problem does this solve?
-      placeholder: It is difficult to...
+      label: Describe the feature
+      description: A clear and concise description of the proposed feature.
     validations:
       required: true
 
   - type: textarea
-    id: proposed-solution
+    id: use-case
     attributes:
-      label: Proposed solution
-      description: How should this work?
+      label: Use Case
+      description: |
+        Why do you need this feature?
+        For example: "I'm always frustrated when..."
     validations:
       required: true
 
   - type: textarea
-    id: scope
+    id: solution
     attributes:
-      label: Scope
-      description: What should be included?
-      placeholder: |
-        - Add ...
-        - Update ...
-        - Document ...
-    validations:
-      required: false
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-      description: What alternatives or workarounds did you consider?
+      label: Proposed Solution
+      description: |
+        Suggest how to implement the addition or change. Please include a
+        prototype, workaround, sketch, or reference implementation.
     validations:
       required: false
 
   - type: textarea
     id: acceptance-criteria
     attributes:
-      label: Acceptance criteria
+      label: Acceptance Criteria
       description: How will maintainers know this is complete?
       value: |
         - [ ] Add the expected behavior
         - [ ] Update tests or docs when applicable
         - [ ] Document validation steps
     validations:
-      required: true
+      required: false
 
   - type: textarea
-    id: validation
+    id: other
     attributes:
-      label: Validation
-      description: Which tests, commands, or manual checks should pass?
-      value: |
-        - [ ] Run the relevant local checks
+      label: Other Information
+      description: |
+        Any alternative solutions or features you considered, a more detailed
+        explanation, stack traces, related issues, links for context, etc.
     validations:
       required: false
 
   - type: checkboxes
-    id: public-safety
+    id: ack
     attributes:
-      label: Public-safety confirmation
+      label: Acknowledgements
       options:
-        - label: This request does not include secrets, private URLs, or
-            internal-only project references
-          required: true
+        - label: I may be able to implement this feature request
+          required: false
+        - label: This feature might incur a breaking change
+          required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version used
+      description: |
+        Please provide the version of the repository or tool you are using.
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment details (OS name and version, etc.)
+    validations:
+      required: true
 
   - type: checkboxes
-    id: contribution
+    id: public-safety
     attributes:
-      label: Contribution
+      label: Public issue checklist
       options:
-        - label: I am willing to submit a pull request for this feature
-          required: false
+        - label: This request does not include secrets or private project links
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,3 +1,4 @@
+---
 name: Feature request
 description: Suggest an improvement or new capability
 title: "[Feature]: "
@@ -7,7 +8,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting an improvement. Please keep the proposal public-safe and avoid private project links.
+        Thanks for suggesting an improvement. Please keep the proposal public
+        safe and avoid private project links.
 
   - type: textarea
     id: problem
@@ -73,7 +75,8 @@ body:
     attributes:
       label: Public-safety confirmation
       options:
-        - label: This request does not include secrets, private URLs, or internal-only project references
+        - label: This request does not include secrets, private URLs, or
+            internal-only project references
           required: true
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/good-first-issue.yml
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.yml
@@ -1,0 +1,87 @@
+name: Good first issue
+description: Propose a well-scoped task for new contributors
+title: "[Good First Issue]: "
+labels: [good first issue, help wanted, needs-triage]
+type: Task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to propose small, well-scoped tasks that help new contributors get started.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should be done?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this useful for the project and for contributors?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Keep this small and explicit.
+      value: |
+        - 
+        - 
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Suggested files or areas
+      description: Point contributors to likely starting points.
+      placeholder: README.md, docs/..., examples/..., packages/...
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ] 
+        - [ ] 
+        - [ ] 
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: Commands or manual checks a contributor can run locally.
+      value: |
+        - [ ] 
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What should contributors avoid changing?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contributor-ready
+    attributes:
+      label: Contributor readiness
+      options:
+        - label: This task does not require private credentials or internal systems
+          required: true
+        - label: This task has a clear validation path
+          required: true
+        - label: This task is small enough for a first contribution
+          required: true

--- a/.github/ISSUE_TEMPLATE/good-first-issue.yml
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.yml
@@ -33,8 +33,8 @@ body:
       label: Scope
       description: Keep this small and explicit.
       value: |
-        - 
-        - 
+        - Add or update one focused area
+        - Keep the change local to the documented scope
     validations:
       required: true
 
@@ -52,9 +52,9 @@ body:
     attributes:
       label: Acceptance criteria
       value: |
-        - [ ] 
-        - [ ] 
-        - [ ] 
+        - [ ] The change is small and focused
+        - [ ] The expected output is documented
+        - [ ] Validation steps are included
     validations:
       required: true
 
@@ -64,7 +64,7 @@ body:
       label: Validation
       description: Commands or manual checks a contributor can run locally.
       value: |
-        - [ ] 
+        - [ ] Run the documented local check
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/good-first-issue.yml
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.yml
@@ -1,21 +1,21 @@
 ---
-name: Good first issue
+name: "🌱 Good First Issue"
 description: Propose a well-scoped task for new contributors
-title: "[Good First Issue]: "
-labels: [good first issue, help wanted, needs-triage]
-type: Task
+title: "[GOOD FIRST ISSUE]: short issue description"
+labels: [good first issue, help wanted]
+assignees: []
 body:
   - type: markdown
     attributes:
       value: |
-        Use this template to propose small, well scoped tasks that help new
+        Use this template to propose small, well-scoped tasks that help new
         contributors get started.
 
   - type: textarea
-    id: summary
+    id: description
     attributes:
-      label: Summary
-      description: What should be done?
+      label: Describe the task
+      description: A clear and concise description of what should be done.
     validations:
       required: true
 
@@ -48,17 +48,6 @@ body:
       required: false
 
   - type: textarea
-    id: acceptance-criteria
-    attributes:
-      label: Acceptance criteria
-      value: |
-        - [ ] The change is small and focused
-        - [ ] The expected output is documented
-        - [ ] Validation steps are included
-    validations:
-      required: true
-
-  - type: textarea
     id: validation
     attributes:
       label: Validation
@@ -71,7 +60,7 @@ body:
   - type: textarea
     id: out-of-scope
     attributes:
-      label: Out of scope
+      label: Out of Scope
       description: What should contributors avoid changing?
     validations:
       required: false
@@ -79,10 +68,9 @@ body:
   - type: checkboxes
     id: contributor-ready
     attributes:
-      label: Contributor readiness
+      label: Contributor Readiness
       options:
-        - label: This task does not require private credentials or internal
-            systems
+        - label: This task does not require private credentials or systems
           required: true
         - label: This task has a clear validation path
           required: true

--- a/.github/ISSUE_TEMPLATE/good-first-issue.yml
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.yml
@@ -1,3 +1,4 @@
+---
 name: Good first issue
 description: Propose a well-scoped task for new contributors
 title: "[Good First Issue]: "
@@ -7,7 +8,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this template to propose small, well-scoped tasks that help new contributors get started.
+        Use this template to propose small, well scoped tasks that help new
+        contributors get started.
 
   - type: textarea
     id: summary
@@ -79,7 +81,8 @@ body:
     attributes:
       label: Contributor readiness
       options:
-        - label: This task does not require private credentials or internal systems
+        - label: This task does not require private credentials or internal
+            systems
           required: true
         - label: This task has a clear validation path
           required: true

--- a/.github/ISSUE_TEMPLATE/infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yml
@@ -1,16 +1,15 @@
 ---
-name: Infrastructure, CI, or tooling
+name: "🛠️ Infrastructure, CI, or Tooling"
 description: Suggest CI, automation, tooling, or repository config changes
-title: "[Infra]: "
-labels: [infrastructure, needs-triage]
-type: Task
+title: "[INFRA]: short issue description"
+labels: [infrastructure]
+assignees: []
 body:
   - type: markdown
     attributes:
       value: |
-        Use this template for public safe CI, GitHub Actions, tooling,
-        development container, linting, release, or repository configuration
-        changes.
+        Use this template for CI, GitHub Actions, tooling, dev containers,
+        linting, release, or repository configuration changes.
 
   - type: textarea
     id: motivation
@@ -21,9 +20,9 @@ body:
       required: true
 
   - type: textarea
-    id: proposed-change
+    id: proposal
     attributes:
-      label: Proposed change
+      label: Proposed Change
       description: What should be added, changed, or removed?
     validations:
       required: true
@@ -31,22 +30,11 @@ body:
   - type: textarea
     id: impact
     attributes:
-      label: Contributor impact
-      description: How does this affect contributors, maintainers, CI runtime,
-        cost, or security?
+      label: Impact
+      description: How does this affect contributors, maintainers, CI, or DX?
+      placeholder: Faster CI, better DX, security improvement, etc.
     validations:
       required: false
-
-  - type: textarea
-    id: acceptance-criteria
-    attributes:
-      label: Acceptance criteria
-      value: |
-        - [ ] Add the requested infrastructure or tooling change
-        - [ ] Document contributor impact
-        - [ ] Keep public configuration safe
-    validations:
-      required: true
 
   - type: textarea
     id: validation
@@ -56,15 +44,14 @@ body:
       value: |
         - [ ] Run the affected workflow or local check
     validations:
-      required: true
+      required: false
 
   - type: checkboxes
     id: confirmation
     attributes:
       label: Confirmation
       options:
-        - label: This request does not include secrets, private URLs, or
-            internal-only project references
+        - label: I understand this may affect all contributors
           required: true
-        - label: I understand this may affect all contributors to the repository
+        - label: This request does not include secrets or private project links
           required: true

--- a/.github/ISSUE_TEMPLATE/infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yml
@@ -1,6 +1,6 @@
 ---
 name: Infrastructure, CI, or tooling
-description: Suggest changes to CI, automation, tooling, or repository configuration
+description: Suggest CI, automation, tooling, or repository config changes
 title: "[Infra]: "
 labels: [infrastructure, needs-triage]
 type: Task
@@ -42,9 +42,9 @@ body:
     attributes:
       label: Acceptance criteria
       value: |
-        - [ ] 
-        - [ ] 
-        - [ ] 
+        - [ ] Add the requested infrastructure or tooling change
+        - [ ] Document contributor impact
+        - [ ] Keep public configuration safe
     validations:
       required: true
 
@@ -54,7 +54,7 @@ body:
       label: Validation
       description: Which commands, checks, or workflows should be run?
       value: |
-        - [ ] 
+        - [ ] Run the affected workflow or local check
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yml
@@ -1,0 +1,65 @@
+name: Infrastructure, CI, or tooling
+description: Suggest changes to CI, automation, devcontainers, tooling, or repository configuration
+title: "[Infra]: "
+labels: [infrastructure, needs-triage]
+type: Task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for public-safe CI, GitHub Actions, tooling, devcontainer, linting, release, or repository configuration changes.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this change needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-change
+    attributes:
+      label: Proposed change
+      description: What should be added, changed, or removed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Contributor impact
+      description: How does this affect contributors, maintainers, CI runtime, cost, or security?
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ] 
+        - [ ] 
+        - [ ] 
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: Which commands, checks, or workflows should be run?
+      value: |
+        - [ ] 
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: This request does not include secrets, private URLs, or internal-only project references
+          required: true
+        - label: I understand this may affect all contributors to the repository
+          required: true

--- a/.github/ISSUE_TEMPLATE/infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/infrastructure.yml
@@ -1,5 +1,6 @@
+---
 name: Infrastructure, CI, or tooling
-description: Suggest changes to CI, automation, devcontainers, tooling, or repository configuration
+description: Suggest changes to CI, automation, tooling, or repository configuration
 title: "[Infra]: "
 labels: [infrastructure, needs-triage]
 type: Task
@@ -7,7 +8,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this template for public-safe CI, GitHub Actions, tooling, devcontainer, linting, release, or repository configuration changes.
+        Use this template for public safe CI, GitHub Actions, tooling,
+        development container, linting, release, or repository configuration
+        changes.
 
   - type: textarea
     id: motivation
@@ -29,7 +32,8 @@ body:
     id: impact
     attributes:
       label: Contributor impact
-      description: How does this affect contributors, maintainers, CI runtime, cost, or security?
+      description: How does this affect contributors, maintainers, CI runtime,
+        cost, or security?
     validations:
       required: false
 
@@ -59,7 +63,8 @@ body:
     attributes:
       label: Confirmation
       options:
-        - label: This request does not include secrets, private URLs, or internal-only project references
+        - label: This request does not include secrets, private URLs, or
+            internal-only project references
           required: true
         - label: I understand this may affect all contributors to the repository
           required: true


### PR DESCRIPTION
## Summary

- Standardizes public-safe issue forms for bugs, features, documentation, infrastructure/tooling, and good first issues.
- Adds contributor-focused prompts for acceptance criteria, validation, scope, and public-safety checks.
- Avoids GitHub Project links, private repository links, secrets, and internal-only references.

## Validation

- Parsed all issue template YAML files successfully with Ruby YAML.
- Ran a self-review for public-safety, contributor clarity, labels, and issue-form consistency.

## Notes

This change supports contributor engagement by making approachable tasks easier to propose and pick up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned issue forms for bug reports, documentation requests, and feature requests with clearer, structured prompts.
  * Added new templates for good-first-issue tasks and infrastructure, CI, or tooling requests.
  * Added required confirmations, acceptance criteria, validation details, and optional supporting information fields.
  * Updated issue configuration to disable blank issues and provide a dedicated contact link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->