### PR TITLE
fix(security): add explicit permissions to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
   schedule:
@@ -19,27 +18,41 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: Shellcheck
+    permissions:
+      contents: read
     uses: ./.github/workflows/shellcheck.yml
 
   tf-check:
     name: Terraform Check
+    permissions:
+      contents: read
     uses: ./.github/workflows/tf-check.yml
 
   markdownlint:
     name: Markdownlint
+    permissions:
+      contents: read
     uses: ./.github/workflows/markdownlint.yml
 
   todo:
     if: github.event_name == 'push'
     name: TODO
+    permissions:
+      contents: read
+      issues: write
     uses: ./.github/workflows/todo.yml
 
   update-readme:
     if: github.event_name == 'push'
     name: Update README
+    permissions:
+      contents: write
     uses: ./.github/workflows/generate-readme.yml
 
   pr-review:

--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -3,6 +3,9 @@ name: Generate README
 on:
   workflow_call:
 
+permissions:
+  contents: write
+
 jobs:
   generate-readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -3,6 +3,9 @@ name: Markdown Lint
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     name: Markdown Lint

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,6 +3,9 @@ name: Shellcheck
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/tf-check.yml
+++ b/.github/workflows/tf-check.yml
@@ -3,6 +3,9 @@ name: Terraform Check
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   tf-fmt-check:
     name: Check Formatting

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -3,6 +3,10 @@ name: Todo Checker
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   todo:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds explicit `permissions` blocks to all GitHub Actions workflow files to resolve code scanning alerts for `actions/missing-workflow-permissions`
- Follows principle of least privilege: each workflow declares only the permissions it actually needs

## Alerts resolved

Closes code scanning alerts: #9, #10, #12, #13, #14, #15, #17, #18, #19, #21

## Changes

| Workflow | Permissions granted |
|----------|-------------------|
| `shellcheck.yml` | `contents: read` |
| `markdownlint.yml` | `contents: read` |
| `tf-check.yml` | `contents: read` |
| `todo.yml` | `contents: read`, `issues: write` |
| `generate-readme.yml` | `contents: write` |
| `ci.yml` | Top-level `contents: read` + per-job overrides matching each called workflow |

## Test plan

- [ ] CI passes on this PR
- [ ] Code scanning re-scan closes the flagged alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - GitHub Actions now use explicitly defined, least-privilege permissions.
  - Automated checks and validation workflows are limited to read-only repository access where appropriate.

- **Automation**
  - README generation can continue updating repository documentation automatically.
  - Todo automation can update issues as needed.
  - Manual workflow triggering remains available without unnecessary configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->