### PR TITLE
fix(ci): fall back to GITHUB_TOKEN when DANGER_GITHUB_API_TOKEN is unset

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -49,4 +49,7 @@ jobs:
         run: npx danger ci --dangerfile dangerfile.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+          # Fall back to GITHUB_TOKEN when the optional DANGER_GITHUB_API_TOKEN
+          # secret is not configured; an empty token makes Danger's
+          # unauthenticated API calls fail (e.g. ERR_STREAM_PREMATURE_CLOSE).
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Downstream repos (e.g. `nanlabs/awesome-nan` PRs #21 and #22) fail the shared `Pull Request Validation / pr-review` job because `DANGER_GITHUB_API_TOKEN` resolves to an empty string when the `DANGER_GITHUB_API_TOKEN` secret is not configured. Danger then issues unauthenticated GitHub API calls that fail with `FetchError: ... ERR_STREAM_PREMATURE_CLOSE` while fetching PR files/commits (observed 3 consecutive failures on `awesome-nan` runs 33918475764 and 33920605403, including after rerun).

This change falls back to `secrets.GITHUB_TOKEN` when the optional secret is unset, so Danger always authenticates.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- Inspected failing logs of `nanlabs/awesome-nan` runs 33918475764 / 33920605403: `DANGER_GITHUB_API_TOKEN:` is empty and every `api.github.com` fetch fails with `ERR_STREAM_PREMATURE_CLOSE`.
- After merge, plan to rerun the failing downstream checks (they consume this workflow via `nanlabs/devops-reference/.github/workflows/pr-review.yml@main`) and confirm they pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated review workflow reliability by allowing it to use the available authentication token when an optional token is not configured.
  - This helps ensure pull request checks continue running across different repository configurations without requiring additional setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->